### PR TITLE
add doc links generation in definitions

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -9,6 +9,11 @@ cp index.html "$root/www-root"
 # use a higher depth because bootstrap might be broken with depth 1?
 if [ ! -d 'rust' ]; then
     git clone --depth 50 https://github.com/rust-lang/rust.git
+    pushd rust
+    git ls-files -z -- ':(glob)library/**/*.rs' \
+    | xargs -0 sed -i'' -E 's@^[[:space:]]*#!?\[doc\(cfg.*$@// & // commented out for std.noratrieb.dev@'
+    git apply ../disable-cfg-doc.patch
+    popd
 fi
 cd rust
 
@@ -43,7 +48,9 @@ for target in "${targets[@]}"; do
         --document-hidden-items \
         --html-before-content=$root/before.html \
         --extend-css=$root/style.css \
-        --cap-lints=allow"
+        --cap-lints=allow \
+        --generate-link-to-definition \
+        --generate-macro-expansion"
 
     ./x doc library --target "$target" --stage 1
 

--- a/disable-cfg-doc.patch
+++ b/disable-cfg-doc.patch
@@ -1,0 +1,22 @@
+diff --git a/src/librustdoc/core.rs b/src/librustdoc/core.rs
+index 375f833831..942dba29e6 100644
+--- a/src/librustdoc/core.rs
++++ b/src/librustdoc/core.rs
+@@ -202,7 +202,7 @@ pub(crate) fn create_config(
+         diagnostic_width,
+         libs,
+         externs,
+-        mut cfgs,
++        cfgs,
+         check_cfgs,
+         codegen_options,
+         unstable_opts,
+@@ -220,7 +220,7 @@ pub(crate) fn create_config(
+     render_options: &RenderOptions,
+ ) -> rustc_interface::Config {
+     // Add the doc cfg into the doc build.
+-    cfgs.push("doc".to_string());
++    // cfgs.push("doc".to_string());
+ 
+     // By default, rustdoc ignores all lints.
+     // Specifically unblock lints relevant to documentation or the lint machinery itself.


### PR DESCRIPTION
It’s the workaround I mentioned here: [#t-infra > stdrs.dev replacement @ 💬](https://rust-lang.zulipchat.com/#narrow/channel/242791-t-infra/topic/stdrs.2Edev.20replacement/near/576661534), as a PR 🦀 

This basically seems to work fine, as far as I can tell by running it locally and taking a glance at the result. This should fix #1